### PR TITLE
Add WebSocketClient.gd to fix 4.0beta3 compat

### DIFF
--- a/addons/com.heroiclabs.nakama/socket/WebSocketClient.gd
+++ b/addons/com.heroiclabs.nakama/socket/WebSocketClient.gd
@@ -1,0 +1,73 @@
+extends Node
+class_name WebSocketClient
+
+@export var handshake_headers := PackedStringArray()
+@export var supported_protocols := PackedStringArray()
+@export var tls_trusted_certificate : X509Certificate = null
+@export var tls_verify := true
+
+
+var socket = WebSocketPeer.new()
+var last_state = WebSocketPeer.STATE_CLOSED
+
+
+signal connected_to_server()
+signal connection_closed()
+signal message_received(message: Variant)
+
+
+func connect_to_url(url) -> int:
+	socket.supported_protocols = supported_protocols
+	socket.handshake_headers = handshake_headers
+	var err = socket.connect_to_url(url, tls_verify, tls_trusted_certificate)
+	if err != OK:
+		return err
+	last_state = socket.get_ready_state()
+	return OK
+
+
+func send(message) -> int:
+	if typeof(message) == TYPE_STRING:
+		return socket.send_text(message)
+	return socket.send(var_to_bytes(message))
+
+
+func get_message() -> Variant:
+	if socket.get_available_packet_count() < 1:
+		return null
+	var pkt = socket.get_packet()
+	if socket.was_string_packet():
+		return pkt.get_string_from_utf8()
+	return bytes_to_var(pkt)
+
+
+func close(code := 1000, reason := "") -> void:
+	socket.close(code, reason)
+	last_state = socket.get_ready_state()
+
+
+func clear() -> void:
+	socket = WebSocketPeer.new()
+	last_state = socket.get_ready_state()
+
+
+func get_socket() -> WebSocketPeer:
+	return socket
+
+
+func poll() -> void:
+	if socket.get_ready_state() != socket.STATE_CLOSED:
+		socket.poll()
+	var state = socket.get_ready_state()
+	if last_state != state:
+		last_state = state
+		if state == socket.STATE_OPEN:
+			connected_to_server.emit()
+		elif state == socket.STATE_CLOSED:
+			connection_closed.emit()
+	while socket.get_ready_state() == socket.STATE_OPEN and socket.get_available_packet_count():
+		message_received.emit(get_message())
+
+
+func _process(delta):
+	poll()


### PR DESCRIPTION
Godot 4.0 beta 3 broke compatibility with previous WebSocket implementations by removing WebSocketClient and WebSocketServer nodes. (https://github.com/godotengine/godot/pull/66594)

This adds in the official "raw" implementation of the WebSocketClient (found here: https://github.com/Faless/gd-websocket-nodes) to fix compatibility. This isn't a true update to the new WebSocket module, but it keeps things working for now. The NakamaSocketAdapter should eventually be redone to work with the new WebSocketPeer class directly.